### PR TITLE
Fix run-on links, add first-char categorization for quotes/thoughts

### DIFF
--- a/src/components/Record.js
+++ b/src/components/Record.js
@@ -6,7 +6,7 @@ export default function Record({ className, title, createdAt, type, text }) {
     let renderedText = text;
     if (text.startsWith('http')) {
         renderedText = (
-            <a className="link" href="text">
+            <a className="link" href={text}>
                 {text}
             </a>
         );

--- a/src/components/Record.js
+++ b/src/components/Record.js
@@ -3,13 +3,22 @@ import moment from 'moment';
 export default function Record({ className, title, createdAt, type, text }) {
     const formattedTime = moment(createdAt).calendar();
 
+    let renderedText = text;
+    if (text.startsWith('http')) {
+        renderedText = (
+            <a className="link" href="text">
+                {text}
+            </a>
+        );
+    }
+
     return (
         <div
             className={`${className} bg-white w-full border-2 rounded-md flex flex-col p-4`}
         >
             <h3 className="flex-auto text-xl font-semibold">{title}</h3>
             <div className="text-xs pb-2">{formattedTime}</div>
-            <div className="whitespace-pre-wrap">{text}</div>
+            <div className="whitespace-pre-wrap break-all">{renderedText}</div>
         </div>
     );
 }

--- a/src/components/RecordTimelineItem.js
+++ b/src/components/RecordTimelineItem.js
@@ -31,7 +31,7 @@ export default function RecordTimelineItem({
             </div>
 
             <Record
-                className={`flex-auto my-2 ${styles.record}`}
+                className={`my-2 flex-initial ${styles.record}`}
                 id={id}
                 title={title}
                 createdAt={createdAt}
@@ -63,6 +63,11 @@ function getStylesForType(type) {
             return {
                 indicator: '',
                 record: 'opacity-50',
+            };
+        case recordTypes.quote:
+            return {
+                indicator: 'bg-purple-400',
+                record: '',
             };
         default:
             return {

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,7 @@ const recordTypes = {
     meditation: 'MEDITATION',
     thought: 'THOUGHT',
     notion: 'NOTION',
+    quote: 'QUOTE',
 };
 
 const hasuraClaimsKey = 'https://hasura.io/jwt/claims';

--- a/src/services/twilio/smsParser.js
+++ b/src/services/twilio/smsParser.js
@@ -2,6 +2,10 @@ import { recordTypes } from '../../constants';
 
 const MATCHERS = {
     meditation: /^m(\d*)$/i,
+    chars: {
+        quote: 'Q',
+        thought: 'T',
+    },
 };
 const TEST_LINE_LENGTH_MAX = 20;
 
@@ -63,8 +67,10 @@ export default class TwilioSMSParser {
     }
 
     _parseMultiLineSMS() {
-        const title = this._lines[0];
+        // Extract first line to determine category
+        const firstLine = this._lines[0];
 
+        // Collect remaining text as record content
         let text;
         if (this._lines[1] == '') {
             text = this._lines.slice(2).join('\n');
@@ -72,11 +78,30 @@ export default class TwilioSMSParser {
             text = this._lines.slice(1).join('\n');
         }
 
-        return {
-            title,
-            text,
-            raw: this._rawSMS,
-            type: recordTypes.exercise,
-        };
+        switch (firstLine.toUpperCase()) {
+            case MATCHERS.chars.thought:
+                return {
+                    title: 'Thought',
+                    text,
+                    raw: this._rawSMS,
+                    type: recordTypes.thought,
+                };
+
+            case MATCHERS.chars.quote:
+                return {
+                    title: 'Quote',
+                    text,
+                    raw: this._rawSMS,
+                    type: recordTypes.quote,
+                };
+
+            default:
+                return {
+                    title: firstLine,
+                    text,
+                    raw: this._rawSMS,
+                    type: recordTypes.exercise,
+                };
+        }
     }
 }

--- a/src/services/twilio/smsParser.test.js
+++ b/src/services/twilio/smsParser.test.js
@@ -77,6 +77,33 @@ Result: 25:12`,
 Result: 25:12`,
         },
     },
+    {
+        title: 'multi line > categorized as quote',
+        input: `q
+Mood follows action`,
+        expectedOutput: {
+            title: 'Quote',
+            text: 'Mood follows action',
+            type: recordTypes.quote,
+            raw: `q
+Mood follows action`,
+        },
+    },
+    {
+        title: 'multi line > categorized as thought',
+        input: `T
+
+Today has been a beautiful odyssey through dreams that feel only divergent from reality through my own decision.`,
+        expectedOutput: {
+            title: 'Thought',
+            text:
+                'Today has been a beautiful odyssey through dreams that feel only divergent from reality through my own decision.',
+            type: recordTypes.thought,
+            raw: `T
+
+Today has been a beautiful odyssey through dreams that feel only divergent from reality through my own decision.`,
+        },
+    },
 ];
 
 const testFunc = ({ title, input, expectedOutput }) => {


### PR DESCRIPTION
* Fixes bug where long urls overlapped the record container and broke the UI
* Adds support for tagging a message as "quote" or "thought" by prepending the text with a single-character line ("q" or "t", respectively)
* Adds test coverage

### Before
<img width="1209" alt="Screen Shot 2022-01-12 at 12 18 49 PM" src="https://user-images.githubusercontent.com/2758435/149215495-137be288-608d-435f-8c45-c432c81dc67e.png">

### After
<img width="697" alt="Screen Shot 2022-01-12 at 12 19 40 PM" src="https://user-images.githubusercontent.com/2758435/149215539-cd6849cd-8ac8-4d63-b5b4-ee7a2d8f38c4.png">

### "Quote" record
<img width="498" alt="Screen Shot 2022-01-12 at 12 20 19 PM" src="https://user-images.githubusercontent.com/2758435/149215630-6af45c18-b21c-4704-9838-b7f8966d01b1.png">

